### PR TITLE
filters are grouped in an array instead of a dict

### DIFF
--- a/anycluster/MapClusterer.py
+++ b/anycluster/MapClusterer.py
@@ -427,9 +427,11 @@ class MapClusterer():
 
         filterstring = ''
 
-        for column in filters:
+        for filter in filters:
 
-            filterparams = filters[column]
+            column = list(filter.keys())[0]
+
+            filterparams = filter[column]
 
             filterstring += ' AND ('
             

--- a/anycluster/static/anycluster/anycluster.js
+++ b/anycluster/static/anycluster/anycluster.js
@@ -220,7 +220,7 @@ Anycluster.prototype = {
 
 		this.baseURL = settings_.baseURL || "/anycluster/"
 		this.autostart = typeof(settings_.autostart) == "boolean" ? settings_.autostart : true;
-		this.filters = settings_.filters || {};
+		this.filters = settings_.filters || [];
 		this.center = settings_.center || [0,0];
 		this.clusterMethod = settings_.clusterMethod || "grid";
 		this.iconType = settings_.iconType || "exact";

--- a/docs/filters.rst
+++ b/docs/filters.rst
@@ -8,9 +8,9 @@ A filterObject looks like this:
 
 .. code-block:: javascript
 
-   var filterObj = { 
-      "db_column_name" : { "values": value, "operator": operator_string } 
-   }
+   var filterObj = [
+      {"db_column_name" : { "values": value, "operator": operator_string }}
+   ]
 
 
 **value**
@@ -23,10 +23,10 @@ Example:
 
 .. code-block:: javascript
 
-   var filters = { 
-      "color": {"values" : "red", "operator":"!=" }
-	  "number": {"values": [2,3], "operator": "either_="}
-   }
+   var filters = [
+      {"color": {"values" : "red", "operator":"!=" }},
+      {"number": {"values": [2,3], "operator": "either_="}}
+   ]
    
    anyclusterInstance.filter(filters);
 


### PR DESCRIPTION
Aligning the way filters are grouped into an array instead of a dict.

Methods `addFilters` and `removeFilters` in anycluster.js still need to be refactored because they are not so useful at the moment but this is out-of-scope of this PR (since they are not used anywhere anyhow).

More info provided in the issue: https://github.com/biodiv/anycluster/issues/30